### PR TITLE
Rename validation profile to validation preset throughout

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Arguments:
 
 Options:
   -c, --csaf-version <CSAF_VERSION>  Version of CSAF to use [default: 2.0]
-  -p, --preset <PRESET>              The validation preset (formerly known as "profile") to use [default: basic]
+  -p, --preset <PRESET>              The validation preset to use [default: basic]
   -o, --only-test <ONLY_TEST>        Run only the selected test
   -h, --help                         Print help
   -V, --version                      Print version

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Arguments:
 Options:
   -c, --csaf-version <CSAF_VERSION>  Version of CSAF to use [default: 2.0]
   -p, --preset <PRESET>              The validation preset to use [default: basic]
-  -o, --only-test <ONLY_TEST>        Run only the selected test
+  -t, --test-id <TEST_ID>            Run only the selected tests, may be specified multiple times
   -h, --help                         Print help
   -V, --version                      Print version
 ```
@@ -51,6 +51,6 @@ csaf-validator --csaf-version 2.0 my-csaf-2-0-document.json
 # validate a CSAF 2.0 document with profile full
 csaf-validator --csaf-version 2.0 --preset full my-csaf-2-0-document.json
 
-# validate a CSAF 2.1 document with a specific test
-csaf-validator --csaf-version 2.1 --only-test 6.1.34 my-csaf-2-1-document.json
+# validate a CSAF 2.1 document with one specific test
+csaf-validator --csaf-version 2.1 --test-id 6.1.34 my-csaf-2-1-document.json
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ This is work-in-progress.
 If you want to build `csaf-validator` on your own, please install Rust (see https://rustup.rs) and then run
 
 ```bash
-# make sure, submodules are up-to-date
+# make sure submodules are up-to-date
+git submodule init
 git submodule update --remote
 
 # run the tests
@@ -35,7 +36,7 @@ Arguments:
 
 Options:
   -c, --csaf-version <CSAF_VERSION>  Version of CSAF to use [default: 2.0]
-  -p, --profile <PROFILE>            The profile to use [default: basic]
+  -p, --preset <PRESET>              The validation preset (formerly known as "profile") to use [default: basic]
   -o, --only-test <ONLY_TEST>        Run only the selected test
   -h, --help                         Print help
   -V, --version                      Print version
@@ -48,7 +49,7 @@ Some examples to use are included below. Please note that the validation is not 
 csaf-validator --csaf-version 2.0 my-csaf-2-0-document.json
 
 # validate a CSAF 2.0 document with profile full
-csaf-validator --csaf-version 2.0 --profile full my-csaf-2-0-document.json
+csaf-validator --csaf-version 2.0 --preset full my-csaf-2-0-document.json
 
 # validate a CSAF 2.1 document with a specific test
 csaf-validator --csaf-version 2.1 --only-test 6.1.34 my-csaf-2-1-document.json

--- a/csaf-lib/src/csaf/csaf2_0/validation.rs
+++ b/csaf-lib/src/csaf/csaf2_0/validation.rs
@@ -1,15 +1,15 @@
 use super::product_helper::*;
 use super::schema::CommonSecurityAdvisoryFramework;
-use crate::csaf::validation::{Test, Validatable, ValidationProfile};
+use crate::csaf::validation::{Test, Validatable, ValidationPreset};
 use std::collections::{HashMap, HashSet};
 use crate::csaf::helpers::find_duplicates;
 
 impl Validatable<CommonSecurityAdvisoryFramework> for CommonSecurityAdvisoryFramework {
-    fn profiles(&self) -> HashMap<ValidationProfile, Vec<&str>> {
+    fn presets(&self) -> HashMap<ValidationPreset, Vec<&str>> {
         HashMap::from([
-            (ValidationProfile::Basic, Vec::from(["6.1.1", "6.1.2"])),
-            (ValidationProfile::Extended, Vec::from(["6.1.1", "6.1.2"])),
-            (ValidationProfile::Full, Vec::from(["6.1.1", "6.1.2"])),
+            (ValidationPreset::Basic, Vec::from(["6.1.1", "6.1.2"])),
+            (ValidationPreset::Extended, Vec::from(["6.1.1", "6.1.2"])),
+            (ValidationPreset::Full, Vec::from(["6.1.1", "6.1.2"])),
         ])
     }
 

--- a/csaf-lib/src/csaf/csaf2_1/validation.rs
+++ b/csaf-lib/src/csaf/csaf2_1/validation.rs
@@ -1,18 +1,18 @@
 use super::product_helper::*;
 use super::schema::CommonSecurityAdvisoryFramework;
 use crate::csaf::helpers::find_duplicates;
-use crate::csaf::validation::{Test, Validatable, ValidationProfile};
+use crate::csaf::validation::{Test, Validatable, ValidationPreset};
 use std::collections::{HashMap, HashSet};
 
 impl Validatable<CommonSecurityAdvisoryFramework> for CommonSecurityAdvisoryFramework {
-    fn profiles(&self) -> HashMap<ValidationProfile, Vec<&str>> {
+    fn presets(&self) -> HashMap<ValidationPreset, Vec<&str>> {
         HashMap::from([
             (
-                ValidationProfile::Basic,
+                ValidationPreset::Basic,
                 Vec::from(["6.1.1", "6.1.2", "6.1.34"]),
             ),
-            (ValidationProfile::Extended, Vec::from(["6.1.1", "6.1.2"])),
-            (ValidationProfile::Full, Vec::from(["6.1.1", "6.1.2"])),
+            (ValidationPreset::Extended, Vec::from(["6.1.1", "6.1.2"])),
+            (ValidationPreset::Full, Vec::from(["6.1.1", "6.1.2"])),
         ])
     }
 

--- a/csaf-lib/src/csaf/validation.rs
+++ b/csaf-lib/src/csaf/validation.rs
@@ -4,28 +4,28 @@ use std::str::FromStr;
 pub enum ValidationError {}
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
-pub enum ValidationProfile {
+pub enum ValidationPreset {
     Basic,
     Extended,
     Full,
 }
 
-impl FromStr for ValidationProfile {
+impl FromStr for ValidationPreset {
     type Err = ();
 
-    fn from_str(input: &str) -> Result<ValidationProfile, Self::Err> {
+    fn from_str(input: &str) -> Result<ValidationPreset, Self::Err> {
         match input {
-            "basic" => Ok(ValidationProfile::Basic),
-            "extended" => Ok(ValidationProfile::Extended),
-            "full" => Ok(ValidationProfile::Full),
+            "basic" => Ok(ValidationPreset::Basic),
+            "extended" => Ok(ValidationPreset::Extended),
+            "full" => Ok(ValidationPreset::Full),
             _ => Err(()),
         }
     }
 }
 
 pub trait Validate {
-    /// Validates this object according to a validation profile
-    fn validate_profile(&'static self, profile: ValidationProfile);
+    /// Validates this object according to a validation preset
+    fn validate_preset(&'static self, preset: ValidationPreset);
 
     /// Validates this object according to a specific test ID.
     fn validate_by_test(&self, version: &str);
@@ -38,10 +38,10 @@ pub type Test<VersionedDocument> =
 /// This trait MUST be implemented by the struct that represents a CSAF document
 /// in the respective version.
 ///
-/// It can then be used to validate documents with either [validate_by_profile] or [validate_by_test].
+/// It can then be used to validate documents with either [validate_by_preset] or [validate_by_test].
 pub trait Validatable<VersionedDocument> {
-    /// Returns a hashmap containing the test ID per profile
-    fn profiles(&self) -> HashMap<ValidationProfile, Vec<&str>>;
+    /// Returns a hashmap containing the test ID per preset
+    fn presets(&self) -> HashMap<ValidationPreset, Vec<&str>>;
 
     /// Returns a hashmap containing the test function per test ID
     fn tests(&self) -> HashMap<&str, Test<VersionedDocument>>;
@@ -49,16 +49,16 @@ pub trait Validatable<VersionedDocument> {
     fn doc(&self) -> &VersionedDocument;
 }
 
-/// Executes all tests of the specified [profile] against the [target]
+/// Executes all tests of the specified [preset] against the [target]
 /// (which is of type [VersionedDocument], e.g. a CSAF 2.0 document).
-pub fn validate_by_profile<VersionedDocument>(
+pub fn validate_by_preset<VersionedDocument>(
     target: &impl Validatable<VersionedDocument>,
-    profile: ValidationProfile,
+    preset: ValidationPreset,
 ) {
-    println!("Validating document with {:?} profile... \n", profile);
+    println!("Validating document with {:?} preset... \n", preset);
 
     // Loop through tests
-    if let Some(tests) = target.profiles().get(&profile) {
+    if let Some(tests) = target.presets().get(&preset) {
         for test_id in tests {
             println!("Executing Test {}... ", test_id);
             validate_by_test(target, test_id);
@@ -66,7 +66,7 @@ pub fn validate_by_profile<VersionedDocument>(
             println!()
         }
     } else {
-        println!("No tests found for profile")
+        println!("No tests found for preset")
     }
 }
 

--- a/csaf-validator/src/main.rs
+++ b/csaf-validator/src/main.rs
@@ -16,7 +16,7 @@ struct Args {
     #[arg(short, long, default_value = "2.0")]
     csaf_version: String,
 
-    /// The validation preset (formerly known as "profile") to use
+    /// The validation preset to use
     #[arg(short, long, default_value = "basic")]
     preset: String,
 


### PR DESCRIPTION
Replaced all occurrences of 'ValidationProfile' with 'ValidationPreset' to better align terminology with its purpose. Updated associated functions, traits, and usage in documentation and CLI arguments accordingly.
Fixes #5.